### PR TITLE
DFP: Send category slug for targeting

### DIFF
--- a/assets/javascripts/discourse/components/google-dfp-ad.js.es6
+++ b/assets/javascripts/discourse/components/google-dfp-ad.js.es6
@@ -197,7 +197,7 @@ export default Ember.Component.extend({
 
     var self = this;
 
-    if (this.get('loadedGoogletag')) {
+    if (this.get('loadedGoogletag') && this.get('refreshOnChange')) {
       googletag.cmd.push(function() {
         ad.setTargeting('discourse-category', self.get('category') ? self.get('category') : null);
         googletag.pubads().refresh([ad]);

--- a/assets/javascripts/discourse/components/google-dfp-ad.js.es6
+++ b/assets/javascripts/discourse/components/google-dfp-ad.js.es6
@@ -195,8 +195,11 @@ export default Ember.Component.extend({
     var ad = ads[this.get('placement')];
     if (!ad) { return; }
 
+    var self = this;
+
     if (this.get('loadedGoogletag')) {
       googletag.cmd.push(function() {
+        ad.setTargeting('discourse-category', self.get('category') ? self.get('category') : null);
         googletag.pubads().refresh([ad]);
       });
     }
@@ -209,6 +212,7 @@ export default Ember.Component.extend({
       googletag.cmd.push(function() {
         var ad = defineSlot(self.get('placement'), self.siteSettings);
         if (ad) {
+          ad.setTargeting('discourse-category', self.get('category') ? self.get('category') : null);
           googletag.display(self.get('divId'));
           googletag.pubads().refresh([ad]);
         }

--- a/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/discourse-adplugin.hbs
@@ -2,7 +2,7 @@
   {{google-adsense placement="topic-list-top"}}
 {{/if}}
 {{#if siteSettings.dfp_topic_list_top_code}}
-  {{google-dfp-ad placement="topic-list-top" category=category.slug}}
+  {{google-dfp-ad placement="topic-list-top" refreshOnChange=loading category=category.slug}}
 {{/if}}
 {{#if siteSettings.amazon_topic_list_top_src_code}}
   {{amazon-product-links placement="topic-list-top"}}

--- a/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/discourse-adplugin.hbs
@@ -2,7 +2,7 @@
   {{google-adsense placement="topic-list-top"}}
 {{/if}}
 {{#if siteSettings.dfp_topic_list_top_code}}
-  {{google-dfp-ad placement="topic-list-top"}}
+  {{google-dfp-ad placement="topic-list-top" category=category.slug}}
 {{/if}}
 {{#if siteSettings.amazon_topic_list_top_src_code}}
   {{amazon-product-links placement="topic-list-top"}}

--- a/assets/javascripts/discourse/templates/connectors/post-bottom/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/templates/connectors/post-bottom/discourse-adplugin.hbs
@@ -2,7 +2,7 @@
 	{{google-adsense placement="post-bottom"}}
 {{/if}}
 {{#if postSpecificCountDFP}}
-  {{google-dfp-ad placement="post-bottom"}}
+  {{google-dfp-ad placement="post-bottom" category=topic.category.slug}}
 {{/if}}
 {{#if postSpecificCountAmazon}}
   {{amazon-product-links placement="post-bottom"}}

--- a/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-post-stream/discourse-adplugin.hbs
@@ -2,7 +2,7 @@
   {{google-adsense placement="topic-above-post-stream"}}
 {{/if}}
 {{#if siteSettings.dfp_topic_above_post_stream_code}}
-  {{google-dfp-ad placement="topic-above-post-stream" refreshOnChange=model.id}}
+  {{google-dfp-ad placement="topic-above-post-stream" refreshOnChange=model.id category=model.category.slug}}
 {{/if}}
 {{#if siteSettings.amazon_topic_above_post_stream_src_code}}
   {{amazon-product-links placement="topic-above-post-stream"}}

--- a/assets/javascripts/discourse/templates/connectors/topic-above-suggested/discourse-adplugin.hbs
+++ b/assets/javascripts/discourse/templates/connectors/topic-above-suggested/discourse-adplugin.hbs
@@ -2,7 +2,7 @@
   {{google-adsense placement="topic-above-suggested"}}
 {{/if}}
 {{#if siteSettings.dfp_topic_above_suggested_code}}
-  {{google-dfp-ad placement="topic-above-suggested" refreshOnChange=model.id}}
+  {{google-dfp-ad placement="topic-above-suggested" refreshOnChange=model.id category=model.category.slug}}
 {{/if}}
 {{#if siteSettings.amazon_topic_above_suggested_src_code}}
   {{amazon-product-links placement="topic-above-suggested"}}


### PR DESCRIPTION
Hi! As requested on meta (https://meta.discourse.org/t/advertising-plugin-for-discourse-serve-ads-on-your-discourse-forum-official-endorsed/33734/9?u=neil), the category of a topic list and topic will always be sent as one of the ad targeting key-values using the `discourse-category` key, and value is the slug property of the category.

Also, this PR fixes ads not refreshing when going from one topic list to another.