### PR TITLE
DFP: send a 0 value for discourse-category targeting on /latest, /categories, etc so that ads can show there while targeting categories

### DIFF
--- a/assets/javascripts/discourse/components/google-dfp-ad.js.es6
+++ b/assets/javascripts/discourse/components/google-dfp-ad.js.es6
@@ -199,7 +199,7 @@ export default Ember.Component.extend({
 
     if (this.get('loadedGoogletag') && this.get('refreshOnChange')) {
       googletag.cmd.push(function() {
-        ad.setTargeting('discourse-category', self.get('category') ? self.get('category') : null);
+        ad.setTargeting('discourse-category', self.get('category') ? self.get('category') : '0');
         googletag.pubads().refresh([ad]);
       });
     }
@@ -212,7 +212,7 @@ export default Ember.Component.extend({
       googletag.cmd.push(function() {
         var ad = defineSlot(self.get('placement'), self.siteSettings);
         if (ad) {
-          ad.setTargeting('discourse-category', self.get('category') ? self.get('category') : null);
+          ad.setTargeting('discourse-category', self.get('category') ? self.get('category') : '0');
           googletag.display(self.get('divId'));
           googletag.pubads().refresh([ad]);
         }


### PR DESCRIPTION
If topic list ad units are using targeting by discourse-category, there was no way to show them on /latest, /categories, etc. where category is not relevant. With this change, discourse-category will be set to 0 (zero) on those pages so they can be targeted too.