### PR TITLE
FIX: mobile ad with is too wide on 320px wide devices

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -6,7 +6,7 @@
 register_css <<CSS
 
 .google-dfp-ad {
-  padding: 3px;
+  padding: 3px 0;
   margin-bottom: 10px;
   clear: both;
 }
@@ -16,7 +16,7 @@ register_css <<CSS
 }
 
 .google-adsense {
-  padding: 3px;
+  padding: 3px 0;
   margin-bottom: 10px;
   clear: both;
 }


### PR DESCRIPTION
I'm not 100% convinced that this fixes the issue we're seeing on iPhone on www.helloforos.com, but the extra padding on left and right was causing ad units to be wider than 320 px.
